### PR TITLE
DS-4133 - Removing Puerto Rico as a whitelisted country because it's a state within the United States.

### DIFF
--- a/src/CountryListService.php
+++ b/src/CountryListService.php
@@ -9,7 +9,7 @@ class CountryListService
      */
     public function blacklistedCountries(): array
     {
-        return ['AL','BY','BA','BI','CF','HR','CU','KP','CD','IR','IQ','QZ','LA','LB','LY','MK','ME','NI','RS','SO','SS','SD','SY','UA','VE','YE','ZW','BS','BB','BJ','BF','KH','KY','TD','CO','KM','CG','DO','GQ','ER','GN','GW','HT','LS','LR','MG','MM','PA','UG'];
+        return ['AL','BY','BA','BI','CF','HR','CU','KP','CD','IR','IQ','QZ','LA','LB','LY','MK','ME','NI','RS','SO','SS','SD','SY','UA','VE','YE','ZW','BS','BB','BJ','BF','KH','KY','TD','CO','KM','CG','DO','GQ','ER','GN','GW','HT','LS','LR','MG','MM','PA','UG','PR'];
     }
 
     /**

--- a/tests/CountryListServiceTest.php
+++ b/tests/CountryListServiceTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AllDigitalRewards\Tests;
+
+use AllDigitalRewards\CountryMapper\CountryListService;
+use PHPUnit\Framework\TestCase;
+
+class CountryListServiceTest extends TestCase
+{
+    public function testPuertoRicoIsBlacklistedCountry()
+    {
+        self::assertTrue((new CountryListService())->isCountryBlacklisted('PR'));
+    }
+}


### PR DESCRIPTION
## Description
DS-4133 - Removing Puerto Rico as a whitelisted country because it's a state within the United States.

## Jira Issue Link
https://jira.alldigitalrewards.com/browse/DS-4133

## Has the README / documentation been extended if necessary?
N/A

## Does this update require changes to public API documentation? 
No

## Tests
### Are there created tests which fail without the change (if possible)?
Yes

### Are all tests passing?
Yes
<img width="674" alt="Screen Shot 2022-05-24 at 09 58 54" src="https://user-images.githubusercontent.com/6137941/170053924-06b4d7a8-7ee0-45ce-b5c3-41ee8faf84f5.png">


### Have the changes been verified to comply with the security policy requirements?
Yes/No
